### PR TITLE
Add resume link to navbar and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,29 @@
-# [kellenmurphy.github.io](https://kellenmurphy.github.io)
+# [kellenmurphy.github.io](https://kellenmurphy.com)
 
-This repository contains the source code for my [personal blog](https://kellenmurphy.com). This README documents some of the steps needed to add stuff to the site, mainly just for my own reference.
+Source for [kellenmurphy.com](https://kellenmurphy.com) — a Jekyll static site deployed via GitHub Actions to GitHub Pages.
 
-## `gh-pages` branch
-
-This branch is protected, and from this branch the site will get deployed, so make sure to commit to a new branch (i.e. this is getting pushed to `chg081022-add-readme`) and create a PR to merge. Not sure why I'm doing this, but I'm doing it... ¯\\\_(ツ)\_/¯
-
-## Drafts
-
-Create draft posts in [`_drafts`](https://github.com/kellenmurphy/kellenmurphy.github.io/tree/gh-pages/_drafts) directory. Use the following command to run `jekyll` in "draft mode":
+## Local Development
 
 ```bash
-bundle exec jekyll serve --drafts
+bundle exec jekyll serve
 ```
 
-Posts should be created with the following front-matter:
+## Structure
 
-```
----
-layout: post
-title: <title-goes-here>
-category: <category-goes-here>
-tags: <tags-go-here>
----
-```
+- `index.html`, `about.html`, `blog.html` — main pages
+- `_md_pages/` — plain-text markdown alternates rendered at `/index.md`, `/about.md`, `/blog.md` for agent content negotiation (advertised via `<link rel="alternate" type="text/markdown">`)
+- `.well-known/` — machine-readable discovery documents (included in Jekyll build via `_config.yml`)
 
-And here are the rough steps to go through to push the changes to the site.
+## `.well-known` Endpoints
 
-1. Rename the draft with the format `YYYY-MM-DD-title.md` and move from [`_drafts`](https://github.com/kellenmurphy/kellenmurphy.github.io/tree/gh-pages/_drafts) to [`_posts`](https://github.com/kellenmurphy/kellenmurphy.github.io/tree/gh-pages/_posts). 
+| Path | Spec | Purpose |
+|------|------|---------|
+| `/.well-known/openid-configuration` | OIDC Discovery | Declares no active authorization endpoints |
+| `/.well-known/oauth-protected-resource` | RFC 9728 | Declares no protected APIs or auth requirements |
+| `/.well-known/agent-skills/index.json` | agentskills.io v0.2 | Index of machine-readable site metadata (API catalog, MCP server card) |
+| `/.well-known/api-catalog` | RFC 9727 | API catalog listing site resources |
+| `/.well-known/mcp/server-card.json` | SEP-1649 | MCP server card describing this site |
 
-2. Commit to new branch and push changes.
+## Deploying
 
-3. Create and merge the PR.
-
-4. ???
-   
-5. Profit!
-
-Github Action will trigger and redeploy the site, seems to take about 30 seconds. 
+Push to a branch and open a PR against `gh-pages`. GitHub Actions picks up the merge and redeploys in ~30 seconds.

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -38,11 +38,9 @@
         <li class="nav-item">
           <a href="/about" class="nav-link m-2 menu-item nav-active">about</a>
         </li>
-        {% comment %}
         <li class="nav-item">
-          <a href="resume.pdf" class="nav-link m-2 menu-item nav-active">resumé</a>
+          <a href="/resume.pdf" class="nav-link m-2 menu-item nav-active">resumé</a>
         </li>
-        {% endcomment %}
         <li class="nav-item">
           <a href="https://linkedin.com/in/kellenmurphy" target="_new"
             class="nav-link m-2 menu-item nav-active">linkedin</a>


### PR DESCRIPTION
## Summary

- Uncomments the resumé nav link in `navbar.html` and fixes the href to use an absolute path (`/resume.pdf`)
- Replaces the stale blog-workflow README with an accurate description of the site structure, `_md_pages` collection, and `.well-known` endpoints

## Test plan

- [ ] Verify resumé link appears in navbar on all pages
- [ ] Verify `/resume.pdf` resolves correctly
- [ ] Check README renders correctly on GitHub