### PR TITLE
Add GitHub contribution activity chart to homepage

### DIFF
--- a/.github/scripts/fetch-github-activity.py
+++ b/.github/scripts/fetch-github-activity.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+
+QUERY = """
+query($login: String!, $from: DateTime!, $to: DateTime!) {
+  user(login: $login) {
+    contributionsCollection(from: $from, to: $to) {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            contributionCount
+            date
+            weekday
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+def main():
+    token = os.environ.get('GH_ACTIVITY_TOKEN')
+    if not token:
+        print('GH_ACTIVITY_TOKEN not set', file=sys.stderr)
+        sys.exit(1)
+
+    now = datetime.now(timezone.utc)
+    year_ago = now - timedelta(days=365)
+
+    payload = json.dumps({
+        'query': QUERY,
+        'variables': {
+            'login': 'kellenmurphy',
+            'from': year_ago.strftime('%Y-%m-%dT00:00:00Z'),
+            'to': now.strftime('%Y-%m-%dT23:59:59Z'),
+        }
+    }).encode()
+
+    req = urllib.request.Request(
+        'https://api.github.com/graphql',
+        data=payload,
+        headers={
+            'Authorization': f'Bearer {token}',
+            'Content-Type': 'application/json',
+            'User-Agent': 'kellenmurphy-site/1.0',
+        }
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        print(f'HTTP {e.code}: {e.read().decode()}', file=sys.stderr)
+        sys.exit(1)
+
+    if 'errors' in body:
+        print(json.dumps(body['errors'], indent=2), file=sys.stderr)
+        sys.exit(1)
+
+    calendar = body['data']['user']['contributionsCollection']['contributionCalendar']
+    output = {
+        'generated_at': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'total_contributions': calendar['totalContributions'],
+        'weeks': calendar['weeks'],
+    }
+
+    os.makedirs('assets/data', exist_ok=True)
+    with open('assets/data/github-activity.json', 'w') as f:
+        json.dump(output, f)
+
+    print(f"Fetched {calendar['totalContributions']} contributions")
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/fetch-github-activity.yml
+++ b/.github/workflows/fetch-github-activity.yml
@@ -1,0 +1,29 @@
+name: Fetch GitHub Activity
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_ACTIVITY_TOKEN }}
+
+      - name: Fetch contribution data
+        env:
+          GH_ACTIVITY_TOKEN: ${{ secrets.GH_ACTIVITY_TOKEN }}
+        run: python3 .github/scripts/fetch-github-activity.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add assets/data/github-activity.json
+          git diff --staged --quiet || (git commit -m "Update GitHub activity data" && git push)

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -1,1 +1,2 @@
 <script src="/assets/js/webmcp.js"></script>
+{% if page.include_github_activity %}<script src="/assets/js/github-activity.js"></script>{% endif %}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -178,6 +178,23 @@ body {
       padding-right: 1em;
   }
 
+  .gh-activity {
+    max-width: 760px;
+    margin: 0 auto 2rem;
+    padding: 0 1rem;
+    text-align: center;
+
+    .gh-activity-total {
+      font-size: 0.85rem;
+      color: #666;
+      margin-bottom: 0.5rem;
+    }
+
+    .gh-activity-wrap {
+      overflow-x: auto;
+    }
+  }
+
   .about-me {
     max-width: 860px;
     margin: 0 auto;
@@ -450,6 +467,12 @@ html.dark {
           border-color: $dark-hover;
           color: $dark-hover;
         }
+      }
+    }
+
+    .gh-activity {
+      .gh-activity-total {
+        color: $dark-nav-link;
       }
     }
   }

--- a/assets/js/github-activity.js
+++ b/assets/js/github-activity.js
@@ -1,0 +1,73 @@
+(function () {
+  var CELL = 10, GAP = 3, STEP = 13;
+  var LEFT_PAD = 28, TOP_PAD = 20;
+
+  var LIGHT = ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'];
+  var DARK  = ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'];
+  var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+  function level(n) {
+    return n === 0 ? 0 : n <= 3 ? 1 : n <= 6 ? 2 : n <= 9 ? 3 : 4;
+  }
+
+  function render(data) {
+    var el = document.getElementById('github-activity');
+    if (!el) return;
+
+    var dark = document.documentElement.classList.contains('dark');
+    var palette = dark ? DARK : LIGHT;
+    var labelFill = dark ? '#8b949e' : '#666';
+    var weeks = data.weeks;
+    var W = LEFT_PAD + weeks.length * STEP;
+    var H = TOP_PAD + 7 * STEP;
+
+    var monthSVG = '', lastMonth = -1;
+    weeks.forEach(function (week, wi) {
+      if (!week.contributionDays.length) return;
+      var m = new Date(week.contributionDays[0].date + 'T12:00:00Z').getUTCMonth();
+      if (m !== lastMonth) {
+        monthSVG += '<text x="' + (LEFT_PAD + wi * STEP) + '" y="' + (TOP_PAD - 6) +
+          '" font-size="10" fill="' + labelFill + '" font-family="system-ui,sans-serif">' + MONTHS[m] + '</text>';
+        lastMonth = m;
+      }
+    });
+
+    var dayLabelSVG = [[1,'Mon'],[3,'Wed'],[5,'Fri']].map(function (pair) {
+      return '<text x="' + (LEFT_PAD - 4) + '" y="' + (TOP_PAD + pair[0] * STEP + CELL - 1) +
+        '" text-anchor="end" font-size="9" fill="' + labelFill + '" font-family="system-ui,sans-serif">' + pair[1] + '</text>';
+    }).join('');
+
+    var cellSVG = '';
+    weeks.forEach(function (week, wi) {
+      week.contributionDays.forEach(function (day) {
+        var x = LEFT_PAD + wi * STEP;
+        var y = TOP_PAD + day.weekday * STEP;
+        var lv = level(day.contributionCount);
+        var tip = day.contributionCount + (day.contributionCount === 1 ? ' contribution on ' : ' contributions on ') + day.date;
+        cellSVG += '<rect x="' + x + '" y="' + y + '" width="' + CELL + '" height="' + CELL +
+          '" rx="2" fill="' + palette[lv] + '"><title>' + tip + '</title></rect>';
+      });
+    });
+
+    el.innerHTML =
+      '<p class="gh-activity-total">' + data.total_contributions.toLocaleString() + ' contributions in the last year</p>' +
+      '<div class="gh-activity-wrap"><svg width="' + W + '" height="' + H + '" viewBox="0 0 ' + W + ' ' + H + '">' +
+      monthSVG + dayLabelSVG + cellSVG +
+      '</svg></div>';
+  }
+
+  var cached = null;
+  function init() {
+    if (cached) { render(cached); return; }
+    fetch('/assets/data/github-activity.json')
+      .then(function (r) { return r.json(); })
+      .then(function (d) { cached = d; render(d); })
+      .catch(function () {
+        var el = document.getElementById('github-activity');
+        if (el) el.style.display = 'none';
+      });
+  }
+
+  new MutationObserver(init).observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: "Home"
 markdown_url: /index.md
+include_github_activity: true
 ---
 
 <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center">
@@ -13,3 +14,4 @@ markdown_url: /index.md
         </div>
     </div>
 </div>
+<div class="gh-activity" id="github-activity"></div>


### PR DESCRIPTION
## Summary
- Scheduled GitHub Actions workflow fetches contribution data daily via GitHub GraphQL API and commits it as `assets/data/github-activity.json`
- Client-side SVG renderer reads the static JSON and draws a heatmap, re-rendering automatically on dark/light mode toggle
- No third-party runtime dependencies — the only external call is from GitHub Actions to `api.github.com`

## Prerequisites
- `GH_ACTIVITY_TOKEN` secret must be set in repo settings (classic PAT with `public_repo` scope)

## Test plan
- [ ] Merge PR into `gh-pages`
- [ ] Go to Actions → "Fetch GitHub Activity" → Run workflow manually
- [ ] Confirm `assets/data/github-activity.json` is committed and Jekyll deploy triggers
- [ ] Verify chart appears on homepage in both light and dark mode