### PR TITLE
Mobile improvements, accessibility, SEO, and site polish

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: "404 — Not Found"
+description: "Page not found."
+permalink: /404.html
+---
+
+<div class="text-center py-5">
+  <h1 class="display-4 mb-3">404</h1>
+  <p class="lead mb-4">That page doesn't exist — even the best SAML assertions get rejected sometimes.</p>
+  <a href="/" class="btn btn-outline-secondary">Back to home</a>
+</div>

--- a/_includes/body.html
+++ b/_includes/body.html
@@ -1,13 +1,17 @@
 <body>
 
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
   {% include navbar.html %}
 
-  <div class="container">
+  <main class="container" id="main-content">
 
     <div class="row px-2 py-4">
       {{ content }}
     </div>
 
-  </div>
+  </main>
+
+  <footer class="site-footer">&copy; {{ 'now' | date: '%Y' }} Kellen Murphy</footer>
 
 </body>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,14 +4,29 @@
   <meta http-equiv='Content-Security-Policy'
     content="default-src 'self' *.kellenmurphy.com; style-src 'self' data:; script-src 'self'; img-src * 'self' data:">
   <meta name="description" content="{{ page.description | default: site.description }}">
+  <meta name="author" content="{{ site.title }}">
+  <meta name="fediverse:creator" content="@kellenmurphy@infosec.exchange">
+  <link rel="canonical" href="{{ site.url }}{{ page.url | remove: 'index.html' }}">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <meta name="theme-color" content="#f8f9fa" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)">
+  <link rel="author" href="{{ site.url }}/about">
+  <link rel="me" href="https://infosec.exchange/@kellenmurphy">
+  <link rel="me" href="https://linkedin.com/in/kellenmurphy">
+  <link rel="me" href="https://github.com/kellenmurphy">
   <!-- Open Graph -->
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:title" content="{% if page.title == 'Home' %}{{ site.title }} &mdash; {{ site.tagline }}{% else %}{{ page.title }} &mdash; {{ site.title }}{% endif %}">
   <meta property="og:description" content="{{ page.description | default: site.description }}">
   <meta property="og:image" content="{{ site.url }}/assets/images/headshot-2024.png">
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+  <meta property="og:url" content="{{ site.url }}{{ page.url | remove: 'index.html' }}">
   <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary">
+  <meta property="og:locale" content="en_US">
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{% if page.title == 'Home' %}{{ site.title }} &mdash; {{ site.tagline }}{% else %}{{ page.title }} &mdash; {{ site.title }}{% endif %}">
+  <meta name="twitter:description" content="{{ page.description | default: site.description }}">
+  <meta name="twitter:image" content="{{ site.url }}/assets/images/headshot-2024.png">
   <title>{{ site.title }} - {{ page.title }}</title>
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   <script src="/assets/js/theme.js"></script>
@@ -20,4 +35,36 @@
   <link rel="sitemap" type="application/xml" href="/sitemap.xml">
   <link rel="api-catalog" href="/.well-known/api-catalog">
   {% if page.markdown_url %}<link rel="alternate" type="text/markdown" href="{{ page.markdown_url }}">{% endif %}
+  <!-- Structured data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Kellen Murphy",
+    "url": "{{ site.url }}",
+    "jobTitle": "Identity Architect",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "University of Virginia",
+      "url": "https://identity.virginia.edu"
+    },
+    "knowsAbout": [
+      "Identity and Access Management",
+      "SAML",
+      "OpenID Connect",
+      "Shibboleth",
+      "Single Sign-On",
+      "Grouper",
+      "Privileged Access Management"
+    ],
+    "sameAs": [
+      "https://infosec.exchange/@kellenmurphy",
+      "https://linkedin.com/in/kellenmurphy",
+      "https://github.com/kellenmurphy"
+    ],
+    "image": "{{ site.url }}/assets/images/headshot-2024.png",
+    "email": "me@kellenmurphy.com",
+    "description": "Identity Architect & SSO Subject Matter Expert at the University of Virginia."
+  }
+  </script>
 </head>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -7,15 +7,11 @@
       <a class="navbar-brand d-none d-lg-inline-block" href="/">
         <img class="headshot" src="/assets/images/headshot-2024.png" alt="This is me, Kellen Murphy!" />
         Kellen Murphy
-        <subtitle>IAM Architect & SSO SME</subtitle>
+        <span class="navbar-subtitle">IAM Architect & SSO SME</span>
       </a>
 
-      <a class="navbar-brand-two mx-auto d-lg-none d-inline-block" href="/">
-        <img class="headshot" src="/assets/images/headshot-2024.png" alt="This is me, Kellen Murphy!">
-      </a>
-
-      <div class="w-100 toggle">
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar">
+<div class="w-100 toggle">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
       </div>
@@ -35,6 +31,9 @@
           <a href="/blog" class="nav-link m-2 menu-item">archives</a>
         </li>
         {% endcomment %}
+        <li class="nav-item d-lg-none">
+          <a href="/" class="nav-link m-2 menu-item">home</a>
+        </li>
         <li class="nav-item">
           <a href="/about" class="nav-link m-2 menu-item nav-active">about</a>
         </li>
@@ -47,23 +46,17 @@
         <li class="nav-item">
           <a href="https://samlguy.com" target="_blank" class="nav-link m-2 menu-item nav-active">tools</a>
         </li>
-        <li class="nav-item">
-          <a href="https://linkedin.com/in/kellenmurphy" target="_blank" class="nav-link m-2 menu-item nav-active" aria-label="LinkedIn">
+        <li class="nav-item d-flex align-items-center">
+          <a href="https://linkedin.com/in/kellenmurphy" target="_blank" rel="me noopener" class="nav-link m-2 menu-item nav-active" aria-label="LinkedIn">
             <svg width="18" height="18"><use xlink:href="/assets/images/bootstrap-icons.svg#linkedin"></use></svg>
           </a>
-        </li>
-        <li class="nav-item">
-          <a href="https://github.com/kellenmurphy" target="_blank" class="nav-link m-2 menu-item nav-active" aria-label="GitHub">
+          <a href="https://github.com/kellenmurphy" target="_blank" rel="me noopener" class="nav-link m-2 menu-item nav-active" aria-label="GitHub">
             <svg width="18" height="18"><use xlink:href="/assets/images/bootstrap-icons.svg#github"></use></svg>
           </a>
-        </li>
-        <li class="nav-item">
           <a href="mailto:me@kellenmurphy.com" class="nav-link m-2 menu-item nav-active" aria-label="Email">
             <svg width="18" height="18"><use xlink:href="/assets/images/bootstrap-icons.svg#envelope"></use></svg>
           </a>
-        </li>
-        <li class="nav-item d-flex align-items-center ms-1">
-          <button id="theme-toggle" aria-label="Toggle theme" class="theme-toggle-btn">
+          <button id="theme-toggle" aria-label="Toggle theme" class="theme-toggle-btn ms-1">
             <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
               <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -13,10 +13,37 @@ $dark-nav-link: #8b949e;
 $dark-hover: #E57200;
 $dark-border: #30363d;
 
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  padding: 0.5rem 1rem;
+  background: $linkColor;
+  color: #fff;
+  font-size: 0.85rem;
+  text-decoration: none;
+  z-index: 9999;
+  &:focus { top: 0; }
+}
+
 body {
   background: $backgroundColor;
   color: $bodyColor;
   font-family: $bodyFont;
+  padding-bottom: 20px;
+
+  footer.site-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    font-size: 0.6rem;
+    color: #767676;
+    padding: 3px 0;
+    background: $backgroundColor;
+    pointer-events: none;
+  }
 
   footer {
 
@@ -137,15 +164,31 @@ body {
 
     .navbar-brand {
 
-      subtitle {
+      .navbar-subtitle {
         font-size: 0.7rem;
-        color: darkgrey;
+        color: #6f6f6f;
       }
 
     }
 
     #myNavbar {
       text-align: center;
+    }
+
+    @media (max-width: 991.98px) {
+      .navbar-collapse .navbar-nav {
+        display: block !important;
+        margin: 0 !important;
+        text-align: center;
+      }
+      .navbar-collapse .navbar-nav > .nav-item.d-flex {
+        display: flex !important;
+        justify-content: center;
+      }
+      .navbar-collapse .navbar-nav > .nav-item.d-flex .nav-link,
+      .navbar-collapse .navbar-nav > .nav-item.d-flex .theme-toggle-btn {
+        padding: 0.6rem 0.9rem;
+      }
     }
 
     .nav-link,
@@ -178,6 +221,12 @@ body {
       padding-right: 1em;
   }
 
+  .navbar ul li {
+      position: static;
+      left: auto;
+      padding-right: 0;
+  }
+
   .gh-activity {
     max-width: 760px;
     margin: 0 auto 2rem;
@@ -185,13 +234,24 @@ body {
     text-align: center;
 
     .gh-activity-total {
-      font-size: 0.85rem;
+      font-size: 0.72rem;
       color: #666;
-      margin-bottom: 0.5rem;
+      margin-top: 0.5rem;
+      margin-bottom: 0;
+
+      a, a:visited {
+        color: inherit;
+        text-decoration: none;
+      }
+      a:hover {
+        color: $hoverColor;
+        text-decoration: underline;
+      }
     }
 
-    .gh-activity-wrap {
-      overflow-x: auto;
+    a.gh-activity-wrap, a.gh-activity-wrap:visited {
+      display: block;
+      text-decoration: none;
     }
   }
 
@@ -202,6 +262,20 @@ body {
 
   .about-me img {
     max-width: 100%;
+  }
+
+  @media (max-width: 767.98px) {
+    .about-me img {
+      display: block;
+      width: 100%;
+      margin: 0 auto 1rem;
+    }
+
+    .about-me ul li {
+      position: static;
+      left: auto;
+      padding-right: 0;
+    }
   }
 
   .warning {
@@ -373,6 +447,11 @@ html.dark {
     background: $dark-bg;
     color: $dark-body;
 
+    footer.site-footer {
+      color: #8b949e;
+      background: $dark-bg;
+    }
+
     a, a:visited {
       color: $dark-link;
       text-decoration: underline;
@@ -404,10 +483,10 @@ html.dark {
 
       .navbar-brand,
       .navbar-brand-two {
-        color: $dark-body;
+        color: $dark-body !important;
       }
 
-      subtitle {
+      .navbar-subtitle {
         color: #888 !important;
       }
 
@@ -473,6 +552,15 @@ html.dark {
     .gh-activity {
       .gh-activity-total {
         color: $dark-nav-link;
+
+        a, a:visited {
+          color: inherit;
+          text-decoration: none;
+        }
+        a:hover {
+          color: $dark-hover;
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/about.html
+++ b/about.html
@@ -1,14 +1,16 @@
 ---
 layout: default
 title: "About Me"
+description: "About Kellen Murphy — physicist turned IAM consultant, now Identity Architect at the University of Virginia specializing in SAML, OpenID Connect, and enterprise SSO."
 markdown_url: /about.md
+last_modified_at: 2026-05-15
 ---
 
 <div class="clearfix text-justify about-me">
 
     <h1 class="mb-3">{{ page.title }}</h1>
 
-    <img class="float-md-start me-md-4" width="250" style="max-width:250px" src="/assets/images/pandemic_office_mate.jpg"/>
+    <img class="float-md-start me-md-4" width="250" style="max-width:250px" src="/assets/images/pandemic_office_mate.jpg" alt="Kellen's home office with Lucy the cat visible in the background"/>
 
     <p>
         That's my home office — and lurking in the background is Lucy. She's the reason I got into the habit of narrating my debugging sessions out loud. Turns out explaining a SAML assertion to a cat is surprisingly effective. She never once asked what a NameID format was, which honestly puts her ahead of a few SP developers I've worked with.
@@ -34,7 +36,7 @@ markdown_url: /about.md
         I peaked in cuteness at age 3... it's been downhill since then. I wanted to be an architect as a child, mostly because I liked <a href="https://lego.com">Lego</a> and the adults around me shrugged at that and said, "Hey, you could design buildings!" Unfortunately, architects need to know how to draw, so I turned to the other aspect of buildings... structural integrity. That led me for a long time to think I'd be an engineer of some sort, and I had a knack at math and science, so it fit. As it turns out, the adults weren't entirely wrong... I did end up as an architect after all. The "identity" part wasn't in the original plan, but the instinct to figure out how things connect and fit together? That part stuck.
     </p>
 
-    <img class="col-md-2 float-md-end ms-md-2" src="/assets/images/kellen_1987.jpg"/>
+    <img class="col-md-2 float-md-end ms-md-2" src="/assets/images/kellen_1987.jpg" alt="Kellen as a young child, circa 1987"/>
 
     <p>
         At some point along my studies of science, however, I stopped caring about anything other than an unabashed search for knowledge. I wanted to master my understanding of the most fundamental nature of what, exactly, was this thing we called "matter." Unsurprisingly, therefore, I studied physics... first at <a href="https://otterbein.edu" target="_blank">Otterbein College</a> (now Otterbein University), where I pivoted all of my studies toward high-energy nuclear physics, a.k.a. particle physics. I also picked up a degree in math because "might as well."
@@ -51,7 +53,7 @@ markdown_url: /about.md
         I began working on <a href="https://en.wikipedia.org/wiki/Gravitational_lens" target="_blank">weak gravitational lensing</a>, which culminated in my dissertation in December 2013 titled <a href="https://etd.ohiolink.edu/apexprod/rws_etd/send_file/send?accession=ohiou1384957353&disposition=inline" target="_blank">Constraining Cosmology with Weak Gravitational Lensing</a>. I used cross correlation tomography of weak lensing signals to study to what extent dark matter in galaxy clusters bends the light from background galaxies at different redshifts. If we look at how this change in ellipticity varies with the lensed object's distance (effectively the same thing as redshift) we had hoped to build an effective constraint on the dark energy equation of state. The gist of my research was that weak lensing wasn't a very good tool for trying to constrain the cosmological parameters related to dark energy, but in science negative results are good too! Anything that furthers along our understanding of something is <strong>good science</strong>.
     </p>
 
-    <img class="col-md-2 float-md-start me-md-2" src="/assets/images/holly_and_i.jpg"/>
+    <img class="col-md-2 float-md-start me-md-2" src="/assets/images/holly_and_i.jpg" alt="Kellen and Holly"/>
 
     <p>
         While I was in grad school, I met the love of my life, Holly. We married in 2009, and had our twin daughters Hope and Lily in 2012. Right about the same time I was thinking about defending a dissertation and moving on to the next phase of my academic life. That said, the only post-doc opportunities I was seriously considering were in Europe, which is a long way from Athens, OH. Since we really needed help from our local families raising our kids, I decided that an academic career wasn't going to be for me, and that instead I should look for "real" work.
@@ -61,7 +63,7 @@ markdown_url: /about.md
         I was looking at jobs locally as a developer, and given that there weren't many options for that kind of work in Athens, I started a business from which to consolidate my freelancing work, along with picking up some other small-business IT projects locally. In 2016, BCS Engineering acquired my business, mainly to acquire me. I had gotten to know the owners well through our church, where I volunteered with the technical teams focusing on video production. I began working for them, leading their local small-business IT consulting efforts, and moonlighting on some programming projects for the e-commerce side of the business. I wasn't a PHP developer, but I rather quickly became one, and gained substantial experience in the e-commerce market working on the <a href="https://xcart.com" target="_blank">X-cart</a> and <a href="https://business.adobe.com/products/magento/magento-commerce.html" target="_blank">Magento / Adobe Commerce</a> platforms.
     </p>
 
-    <img class="col-md-4 float-md-end ms-md-4" src="/assets/images/hope_and_lily.jpg"/>
+    <img class="col-md-4 float-md-end ms-md-4" src="/assets/images/hope_and_lily.jpg" alt="Kellen's twin daughters Hope and Lily"/>
 
     <p>
         BCSE also owned a sister-company, IDM Integration, along with another business partner. From my first IDMI project upgrading <a href="https://shibboleth.net" target="_blank">Shibboleth</a> IDP in 2016, it was clear that I had a knack for identity and access management, specifically authentication. I threw myself into IAM projects as often as I could, and by 2018 I was playing a pivotal role with IDMI, taking on a "senior" engineering role and being involved in much of the day-to-day operations of the business.

--- a/assets/js/github-activity.js
+++ b/assets/js/github-activity.js
@@ -1,9 +1,11 @@
 (function () {
   var CELL = 10, GAP = 3, STEP = 13;
-  var LEFT_PAD = 28, TOP_PAD = 20;
+  var LEFT_PAD = 28, TOP_PAD = 32;
 
   var LIGHT = ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'];
   var DARK  = ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'];
+  var LIGHT_BORDER = '#d0d7de';
+  var DARK_BORDER  = '#30363d';
   var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 
   function level(n) {
@@ -16,6 +18,7 @@
 
     var dark = document.documentElement.classList.contains('dark');
     var palette = dark ? DARK : LIGHT;
+    var border = dark ? DARK_BORDER : LIGHT_BORDER;
     var labelFill = dark ? '#8b949e' : '#666';
     var weeks = data.weeks;
     var W = LEFT_PAD + weeks.length * STEP;
@@ -45,15 +48,20 @@
         var lv = level(day.contributionCount);
         var tip = day.contributionCount + (day.contributionCount === 1 ? ' contribution on ' : ' contributions on ') + day.date;
         cellSVG += '<rect x="' + x + '" y="' + y + '" width="' + CELL + '" height="' + CELL +
-          '" rx="2" fill="' + palette[lv] + '"><title>' + tip + '</title></rect>';
+          '" rx="2" fill="' + palette[lv] + '" stroke="' + border + '" stroke-width="0.5"><title>' + tip + '</title></rect>';
       });
     });
 
+    var headerSVG = '<text x="6" y="11" font-size="9" fill="' + labelFill +
+      '" font-family="system-ui,sans-serif" font-weight="600">GitHub Activity</text>';
+
     el.innerHTML =
-      '<p class="gh-activity-total">' + data.total_contributions.toLocaleString() + ' contributions in the last year</p>' +
-      '<div class="gh-activity-wrap"><svg width="' + W + '" height="' + H + '" viewBox="0 0 ' + W + ' ' + H + '">' +
-      monthSVG + dayLabelSVG + cellSVG +
-      '</svg></div>';
+      '<a href="https://github.com/kellenmurphy" target="_blank" rel="noopener" class="gh-activity-wrap" aria-label="GitHub contribution activity — view profile">' +
+      '<svg viewBox="0 0 ' + W + ' ' + H + '" style="width:100%;height:auto;" role="img" aria-label="GitHub contribution heatmap for the last year">' +
+      headerSVG + monthSVG + dayLabelSVG + cellSVG +
+      '</svg></a>' +
+      '<p class="gh-activity-total"><small><a href="https://github.com/kellenmurphy" target="_blank" rel="noopener">' +
+      data.total_contributions.toLocaleString() + ' contributions in the last year</a></small></p>';
   }
 
   var cached = null;

--- a/index.html
+++ b/index.html
@@ -1,16 +1,18 @@
 ---
 layout: default
 title: "Home"
+description: "Personal site of Kellen Murphy — Identity Architect and SSO Subject Matter Expert at the University of Virginia."
 markdown_url: /index.md
 include_github_activity: true
+last_modified_at: 2026-05-15
 ---
 
 <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center">
     <div class="mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
         <div class="my-3 p-3">
           <img class="frontpage-circ mb-3" id="headshot" src="/assets/images/headshot-2024.png" alt="A round-faced, male wearing glasses and smiling in black and white." />
-          <h2 class="display-5 mb-3">Hi, I'm Kellen.</h2>
-          <p class="lead">Identity Architect &amp; Single Sign-On Subject Matter Expert</p>
+          <h1 class="display-5 mb-3">Hi, I'm Kellen.</h1>
+          <p class="lead">Identity Architect &amp; SSO Subject Matter Expert</p>
         </div>
     </div>
 </div>

--- a/resume.html
+++ b/resume.html
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: "Resumé"
+description: "Résumé of Kellen Murphy — Identity Architect and SSO Subject Matter Expert at the University of Virginia, with expertise in SAML, OpenID Connect, Shibboleth, and enterprise IAM."
 markdown_url: /resume.md
+last_modified_at: 2026-05-15
 ---
 
 <div class="resume">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,9 +7,7 @@ layout: null
     {% unless page.url contains '.xml' or page.url contains '.txt' or page.url contains '.json' %}
     <url>
       <loc>{{ site.url }}{{ page.url | remove: 'index.html' }}</loc>
-      {% if page.last_modified_at %}
-      <lastmod>{{ page.last_modified_at | date: "%Y-%m-%d" }}</lastmod>
-      {% endif %}
+      <lastmod>{{ page.last_modified_at | default: site.time | date: "%Y-%m-%d" }}</lastmod>
       <changefreq>monthly</changefreq>
     </url>
     {% endunless %}

--- a/talks.html
+++ b/talks.html
@@ -3,6 +3,7 @@ layout: default
 title: "Talks"
 description: "Conference presentations by Kellen Murphy on identity and access management, Grouper, and enterprise IAM."
 markdown_url: /talks.md
+last_modified_at: 2026-05-15
 ---
 
 <div class="talks">
@@ -11,6 +12,22 @@ markdown_url: /talks.md
 
   <section>
     <h2 class="talks-conference"><a href="https://incommon.org/academy/camps-conferences/camp-week" target="_blank">Internet2 Technology Exchange</a></h2>
+
+    <div class="talk">
+      <div class="talk-header">
+        <span class="talk-title">Shibboleth Reborn: NetBadge Under New Stewardship at the University of Virginia</span>
+        <span class="talk-meta"><span class="talk-upcoming">Accepted</span> &middot; TechEx 2026</span>
+      </div>
+      <p class="talk-abstract">
+        When the University of Virginia's Identity Services team assumed operational responsibility for UVA's long-running Shibboleth deployment in 2025, it inherited a stable but stationary service: SAML integrations were well tracked, reliably delivered, and semi-automated, but the service was also ripe for modernization. This session chronicles the first year of that transition: what we found, what we changed, and where we're headed.
+      </p>
+      <p class="talk-abstract">
+        We'll share practical lessons from efforts to tighten SAML attribute hygiene, reduce reliance on email-based identifiers for our Health System, and our custom tooling that makes SAML integrations easier than ever. We'll look ahead at how containerized deployment via Docker Swarm and the InCommon Trusted Access Platform container images will reshape our release pipeline. And lastly, we'll discuss how we're aiming to improve customer service by simplifying bulk integrations for technically adept users via Keycloak proxying.
+      </p>
+      <p class="talk-abstract">
+        Finally, we'll share how we're beginning to face the question every multitenant institution dreads: how do you converge Shibboleth and Microsoft Entra ID into a unified SSO experience when half of your users are in one (Academic) tenant and the other half are in a separate (Health System) tenant?
+      </p>
+    </div>
 
     <div class="talk">
       <div class="talk-header">


### PR DESCRIPTION
## Summary

- **Mobile & UI** — removed navbar headshot on mobile, added home link, centered about page images, fixed ul indentation, grouped icons into a single tap-friendly row, made GitHub activity chart responsive and clickable, added fixed copyright footer
- **Accessibility** — skip-to-content link, `<main>` landmark, `h1` on homepage, color contrast fixes across footer and navbar (light + dark mode), alt text on all about page images, aria labels on navbar toggler
- **SEO** — canonical URL, `rel="me"` (Mastodon/LinkedIn/GitHub), `fediverse:creator` meta, JSON-LD Person schema, upgraded Twitter card, `og:locale`, `theme-color`, favicon declaration, page descriptions and `last_modified_at` on all main pages, sitemap lastmod fallback
- **Content** — TechEx 2026 accepted talk added (Shibboleth Reborn), custom 404 page

## Test plan

- [ ] Mobile layout: navbar, hero text, about images, activity chart all render correctly
- [ ] Dark mode: navbar brand, subtitle, and footer all pass contrast checks
- [ ] Accessibility: run A11y agent — expect 0 violations
- [ ] SEO: validate JSON-LD at schema.org/SchemaValidator, check OG tags with a link preview tool
- [ ] Talks page: TechEx 2026 entry appears at top with "Accepted" badge
- [ ] 404: navigate to `/404` and confirm branded page renders
- [ ] Mastodon verification: confirm green checkmark on infosec.exchange profile after deploy