### PR TITLE
Add IAMOnline 2026 talk: Community As a Verb

### DIFF
--- a/talks.html
+++ b/talks.html
@@ -110,6 +110,17 @@ last_modified_at: 2026-05-15
 
     <div class="talk">
       <div class="talk-header">
+        <span class="talk-title">Community As a Verb: Mapping the Paths from Concepts to Collaboration</span>
+        <span class="talk-meta"><span class="talk-upcoming">Upcoming</span> &middot; IAMOnline 2026 &middot; May 20, 2026</span>
+      </div>
+      <p class="talk-copresenters">With <strong>Claire Chance</strong> &mdash; Colorado State University; <strong>Clay Cooper</strong> &mdash; Rochester Institute of Technology; and <strong>Grady Bailey</strong> &mdash; Internet2</p>
+      <p class="talk-abstract">
+        Much like digital identity isn't merely a collection of attributes, the InCommon Community isn't just a collection of people. Threads of connection and collaboration are constantly being woven into a living, breathing, problem-solving tapestry. A conversation with community leaders about their lived experiences, unique perspectives, and the fabric of the InCommon Community — getting started, navigating common challenges, and how to leverage the power of community to accomplish major feats in research and higher education.
+      </p>
+    </div>
+
+    <div class="talk">
+      <div class="talk-header">
         <span class="talk-title">Change Afoot: Navigating the Hybrid IAM Landscape</span>
         <span class="talk-meta">IAMOnline 2025 &middot; March 19, 2025</span>
       </div>


### PR DESCRIPTION
## Summary

- Adds upcoming IAMOnline 2026 talk (May 20, 2026) to the talks page
- Co-presenters: Claire Chance (CSU), Clay Cooper (RIT), Grady Bailey (Internet2)

## Note

This branch was cut from `mobile-improvements` — merge PR #17 first to avoid conflicts.