### PR TITLE
chore(ci): set dependabot schedule to wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"

--- a/.github/workflows/fetch-github-activity.yml
+++ b/.github/workflows/fetch-github-activity.yml
@@ -2,7 +2,7 @@ name: Fetch GitHub Activity
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 8,10,12,14,16,18,20 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fetch-github-activity.yml
+++ b/.github/workflows/fetch-github-activity.yml
@@ -12,7 +12,7 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GH_ACTIVITY_TOKEN }}
 

--- a/.github/workflows/fetch-github-activity.yml
+++ b/.github/workflows/fetch-github-activity.yml
@@ -2,7 +2,7 @@ name: Fetch GitHub Activity
 
 on:
   schedule:
-    - cron: '0 8,10,12,14,16,18,20 * * *'
+    - cron: '0 0,12,14,16,18,20,22 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -22,17 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           ruby-version: "3.1"
           bundler-cache: true
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -40,7 +40,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
 
   deploy:
     environment:
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- Sets github-actions Dependabot schedule to Wednesday instead of the default Monday

## Test plan
- [ ] Verify Dependabot PRs appear on Wednesdays after merge