### PR TITLE
chore(ci): set dependabot schedule to wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"


### PR DESCRIPTION
## Summary
- Sets github-actions Dependabot schedule to Wednesday instead of the default Monday

## Test plan
- [ ] Verify Dependabot PRs appear on Wednesdays after merge