### PR TITLE
chore: update README title to reflect repo rename

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [kellenmurphy.github.io](https://kellenmurphy.com)
+# [kellenmurphy.com](https://kellenmurphy.com)
 
 Source for [kellenmurphy.com](https://kellenmurphy.com) — a Jekyll static site deployed via GitHub Actions to GitHub Pages.
 


### PR DESCRIPTION
Replaces stale `kellenmurphy.github.io` display text in the README title with `kellenmurphy.com` following the repo rename.